### PR TITLE
build from system by default, vendored option, c++17

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "TileDB"]
 	path = TileDB
 	url = https://github.com/TileDB-Inc/TileDB.git
-	branch = 2.2.1
+	branch = dev

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "tiledb-sys"
-version = "0.1.1"
-authors = ["Bogdan State <bogdan@scie.nz>"]
-edition = "2018"
+version = "0.2.0"
+authors = ["Bogdan State <bogdan@scie.nz>", "Matthew Perry <perrygeo@gmail.com>"]
+edition = "2021"
 links = "tiledb"
 license-file = "LICENSE"
 description = """\
@@ -25,3 +25,8 @@ libc = "0.2.95"
 bindgen = "0.58.1"
 cmake = "0.1"
 fs_extra = "1.2.0"
+pkg-config = "0.3.26"
+num_cpus = "1.15.0"
+
+[features]
+vendored = []

--- a/README.md
+++ b/README.md
@@ -1,12 +1,23 @@
-# tiledb-rust-bind
+# tiledb-sys
+
 Rust Bindings for the [TileDB C API](https://tiledb-inc-tiledb.readthedocs-hosted.com/en/stable/c-api.html),
 generated using bindgen.
 
 # Usage
+
 `Cargo.toml`
+
+By default, it will attempt build bindings against `tiledb` on your system
+
 ```
 [dependencies]
-tiledb-sys = "0.1.1"
+tiledb-sys = "0.2.0"
+```
+
+Otherwise, use the `vendored` feature to build `tiledb` from a git submodule source.
+
+```
+tiledb-sys = { version = "0.2.0", features = ["vendored"] }
 ```
 
 `main.rs`:


### PR DESCRIPTION
A few modifications to the build script to bring it up to date with recent versions of TileDB.

* Following the now-common practice of `*-sys` crates, this will default to using a local library. There is a new `vendored` feature flag if you want to build from a git submodule instead.
* The vendored build itself
    - disables everything possible to speed up build times
    - determines cpu count at build time
    - error handling for failed builds
    - uses the current dev branch
* Upgrade to c++17
* Docs and version number bump